### PR TITLE
Support a split hardware library

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -34,5 +34,5 @@ model01.build.usb_manufacturer="Keyboardio"
 model01.build.board=AVR_MODEL01
 model01.build.core=arduino:arduino
 model01.build.variant=model01
-model01.build.extra_flags={build.usb_flags}
+model01.build.extra_flags={build.usb_flags} -DKEYBOARDIO_HARDWARE_H="Keyboardio-Hardware-Model01.h"
 


### PR DESCRIPTION
Updates the keyboardio-libraries to a version that has the Keyboardio-Hardware-Model01 library added, and adds a flag to the `model01.build.extra_flags` property in boards.txt, that sets `KEYBOARDIO_HARDWARE_H`, required for the core firmware to find the right hardware header.

Depends on keyboardio/keyboardio-libraries#1.