### PR TITLE
Make recursive builds less verbose

### DIFF
--- a/build-tools/test-recursively
+++ b/build-tools/test-recursively
@@ -18,16 +18,26 @@ for my $dir (@files) {
     next if ( !-d $dir );
     next if ( !-f $dir . "/Makefile" );
     chdir($dir);
+    print "$dir($target)...";
     my $has_target = `make -pRrq 2>/dev/null |grep ^travis-test 2>/dev/null`;
     if ($has_target) {
-	print "cd $dir\n";
-	print "make $target\n";
-        system("make $target");
-	my $result = $? >> 8; 
+        system("make -s $target >.build-log 2>&1");
+        my $result = $? >> 8;
 
-	print "Result: $result\n";
-	$failed_count += $result;
-	$run_count++;
+        if ($result == 0) {
+            print " ok\n";
+        } else {
+            my $contents = do { local $/; open my $fh, ".build-log"; <$fh>; };
+            $contents =~ s/^/ > /mg;
+            print " fail\n";
+            print STDERR "\n$contents\n";
+        }
+        unlink(".build-log");
+
+        $failed_count += $result;
+        $run_count++;
+    } else {
+        print " skip\n";
     }
 }
 

--- a/build-tools/test-recursively
+++ b/build-tools/test-recursively
@@ -18,7 +18,7 @@ for my $dir (@files) {
     next if ( !-d $dir );
     next if ( !-f $dir . "/Makefile" );
     chdir($dir);
-    my $has_target = `make -pRrq |grep ^travis-test`;
+    my $has_target = `make -pRrq 2>/dev/null |grep ^travis-test 2>/dev/null`;
     if ($has_target) {
 	print "cd $dir\n";
 	print "make $target\n";


### PR DESCRIPTION
To be able to spot errors quicker, make the verbose runner a little bit more silent. It also highlights the errors hopefully a tiny bit better.

See [here](https://travis-ci.org/keyboardio/Arduino-Boards/builds/239571404) for a sample build. Or the build log of this PR should work, too. :)