### PR TITLE
Fixed $ASTYLE_FILE_PATTERN for BSD grep (and GNU grep)

### DIFF
--- a/build-tools/run-astyle
+++ b/build-tools/run-astyle
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-ASTYLE_FILE_PATTERN='\.h$\|\.cpp$\|\.ino$' 
+ASTYLE_FILE_PATTERN='\(\.h\|\.cpp\|\.ino\)$'
 git ls-files |grep "$ASTYLE_FILE_PATTERN" | xargs -n 1 astyle -q --style=google --unpad-paren --pad-header --pad-oper --indent-classes --indent=spaces=2


### PR DESCRIPTION
The previous pattern worked for GNU grep, so `make astyle` worked fine
on Linux, but not on macOS, which uses BSD grep. This new regex works
for both versions.

Fixes #10.