### PR TITLE
Add the HostPowerManagement plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -157,3 +157,6 @@
 [submodule "libraries/Kaleidoscope-NumPad"]
 	path = libraries/Kaleidoscope-NumPad
 	url = https://github.com/Keyboardio/Kaleidoscope-NumPad
+[submodule "libraries/Kaleidoscope-HostPowerManagement"]
+	path = libraries/Kaleidoscope-HostPowerManagement
+	url = https://github.com/keyboardio/Kaleidoscope-HostPowerManagement


### PR DESCRIPTION
This fixes keyboardio/Kaleidoscope#217 and keyboardio/Kaleidoscope#237, or at least once the new plugin is added to the one's sketch.