### PR TITLE
Added single quotes to command line quoted macro definitions

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -35,4 +35,4 @@ model01.build.usb_manufacturer="Keyboardio"
 model01.build.board=AVR_MODEL01
 model01.build.core=arduino:arduino
 model01.build.variant=model01
-model01.build.extra_flags={build.usb_flags} -DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Model01.h"
+model01.build.extra_flags={build.usb_flags} '-DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Model01.h"'


### PR DESCRIPTION
Missing single quotes around extra flags can cause problems with builds with other build systems.

I am well aware, that Arduino is the only build system officially used and supported by the Kaleidoscope project, but those quotes do not hurt and similar quotes can also be found here.
https://github.com/keyboardio/Arduino-Boards/blob/918f7c1e09193e509c3e5c0ff0441b59af10625f/platform.txt#L122
There, single quotes are used in a similar way to protect the double quotes around the string literals that are assigned to `USB_MANUFACTURER` and `USB_PRODUCT`. It seems strange that those quotes are not required in both places.