### PR TITLE
Removes trailing slash for Kaleidoscope-Hardware

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -147,7 +147,7 @@
 	url = https://github.com/Keyboardio/Model01-Firmware
 [submodule "libraries/Kaleidoscope-Hardware"]
 	path = libraries/Kaleidoscope-Hardware
-	url = https://github.com/Keyboardio/Kaleidoscope-Hardware/
+	url = https://github.com/Keyboardio/Kaleidoscope-Hardware
 [submodule "libraries/Kaleidoscope-NumPad"]
 	path = libraries/Kaleidoscope-NumPad
 	url = https://github.com/Keyboardio/Kaleidoscope-NumPad


### PR DESCRIPTION
I wasn't able to follow the install instructions on https://github.com/keyboardio/Model01-Firmware due to a trailing slash on the Kaleidoscope-Hardware submodule entry. Removing it corrected the issue.